### PR TITLE
0.3 candidate

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,12 @@
+0.3.0 / 2015-12-24
+==================
+
+  * deps: esprima@^2.7.1
+    - Adds support for parsing ES6 code
+  * deps: lodash@^3.10.1
+    - Replaces `underscore`, `clone` and `deep-extend`
+  * deps: async@^1.5.0
+  * deps: glob-stream@^5.3.1
+
+  * Remove unused `on-finished` dep
+

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Will be extracted metadata information for the following routes:
 
 **Notice** that methods and urls should exactly match to your mounted express route handlers (case sensitive ;)
 
-### `autopopulate` property 
+### `autopopulate` property
 
 When enabled will intercept all incoming requests and their responses and upon `kill` chemical will dump at `dna.docsMetadata` `{.source} \ {.populateFilename}.json` json data documentation with samples 'schemified'.
 
 ### `renderAutopopulatedDocs` property
 
-When enabled will load and render `dna.docsMetadata` `{.source} \ {.populateFilename}.json` json data documentation into `dna.docsMetadata` `{.source} \ {.populateFilename}` markdown file suitable 
+When enabled will load and render `dna.docsMetadata` `{.source} \ {.populateFilename}.json` json data documentation into `dna.docsMetadata` `{.source} \ {.populateFilename}` markdown file suitable
 for parsing by docsMetadata pipeline.
 
 *Noteice* that this happens when the organelle is constructed, therefore it won't output anything if the json file is missing.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var Nucleus = require("organic-nucleus")
 var Plasma = require("organic-plasma")
-var clone = require("clone")
+var _ = require("lodash")
 var async = require("async")
 
 var ExpressDoc = require("./lib/express-app-to-documentation")
@@ -11,7 +11,7 @@ var fs = require("fs")
 var path = require("path")
 
 var acquireOrganelleDNA = function(dna){
-  var result = clone(dna)
+  var result = _.cloneDeep(dna)
   result.reactOn = "document"
   result.emitReady = "documentDone"
   result.log = false
@@ -47,7 +47,7 @@ var generateDocs = function(dna, done){
     subplasma.emit({
       type: "document",
       data: fakeExpress
-    })  
+    })
   }, function(err){
     // once all organelles completed
     if(err) return done(err)
@@ -87,18 +87,18 @@ module.exports = function(plasma, dna) {
     plasma.on(dna.reactOn, function(c){
       var app = c.data || c[0].data
       var responseBuffer = { html: "", generatedDocs: null}
-      
+
       if(dna.docsMetadata) {
         if(!dna.docsMetadata.populateFilename)
           dna.docsMetadata.populateFilename = "api.md"
         dna.docsMetadata.jsonStoreFilepath = path.join(
-          process.cwd(), 
-          dna.docsMetadata.source, 
+          process.cwd(),
+          dna.docsMetadata.source,
           dna.docsMetadata.populateFilename+".json"
         )
         dna.docsMetadata.markdownFilepath = path.join(
-          process.cwd(), 
-          dna.docsMetadata.source, 
+          process.cwd(),
+          dna.docsMetadata.source,
           dna.docsMetadata.populateFilename
         )
         if(dna.docsMetadata.autopopulate) {
@@ -124,8 +124,8 @@ module.exports = function(plasma, dna) {
       if(dna.routes) {
         if(dna.docsMetadata && dna.docsMetadata.renderAutopopulatedDocs) {
           populatedDocsRender.loadAndRenderMarkdown(
-            dna.docsMetadata.jsonStoreFilepath, 
-            dna.docsMetadata.markdownFilepath, 
+            dna.docsMetadata.jsonStoreFilepath,
+            dna.docsMetadata.markdownFilepath,
             function(err){
               if(err) return console.error(err)
               console.info(dna.docsMetadata.markdownFilepath, "markdown docs updated")

--- a/lib/documentation-generator.js
+++ b/lib/documentation-generator.js
@@ -25,7 +25,7 @@ module.exports.prototype.generateHtml = function(doc, done) {
   var self = this
   this.transformActionCommentsToHtml(doc, function(err){
     if(err) return done(err)
-    if(!self.metadata) 
+    if(!self.metadata)
       return self.render(doc, done)
     var parser = null
     if(!self.metadata.parserPath)
@@ -36,7 +36,7 @@ module.exports.prototype.generateHtml = function(doc, done) {
       return done(new Error("parser not found for "+JSON.stringify(self.metadata)))
     parser.loadAndRenderMetadata(self.metadata, doc, function(err){
       if(err) return done(err)
-      self.render(doc, done)  
+      self.render(doc, done)
     })
   })
 }

--- a/lib/express-app-to-documentation.js
+++ b/lib/express-app-to-documentation.js
@@ -1,6 +1,6 @@
 var esprima = require("esprima")
 var path = require("path")
-var _ = require("underscore")
+var _ = require("lodash")
 
 var Documentation = require("./models/documentation")
 var Api = require("./models/api")
@@ -56,9 +56,8 @@ module.exports.prototype.generateDocumentation = function() {
 }
 
 module.exports.prototype.extractApis = function(actions){
-  actions = _.sortBy(actions, function(a){
-    return a.url
-  })
+  actions = _.sortBy(actions, 'url')
+
   var apis = []
   /*
    0 /api/vesrion
@@ -87,7 +86,7 @@ module.exports.prototype.extractApis = function(actions){
 
     if(isNew)
       for(var k = 0; k<apis.length; k++) {
-        if(recognizedActionBaseUrl.indexOf(apis[k].baseUrl) == 0 && 
+        if(recognizedActionBaseUrl.indexOf(apis[k].baseUrl) == 0 &&
           (actions[i].url.indexOf("/:") != -1 || actions[i].url.indexOf("*") != -1)) {
           isNew = false
           apis[k].actions.push(this.extractAction(actions[i]))
@@ -102,13 +101,12 @@ module.exports.prototype.extractApis = function(actions){
       }))
     }
   }
-  apis = _.sortBy(apis, function(a){
-    return a.baseUrl
-  })
+
+  apis = _.sortBy(apis, 'baseUrl')
+
   var CRUD = ["all", "post", "get", "put", "delete"]
   for(var i = 0; i<apis.length; i++) {
     apis[i].actions = _(apis[i].actions)
-      .chain()
       .sortBy(function(a){
         return CRUD.indexOf(a.method)
       })

--- a/lib/populate-docs-metadata/index.js
+++ b/lib/populate-docs-metadata/index.js
@@ -1,9 +1,7 @@
 var fs = require('fs')
 var BufferRes = require('express-buffer-response')
 var url = require("url")
-var _ = require("underscore")
-
-var deepExtend = require("deep-extend")
+var _ = require("lodash")
 
 var routes_map = {/*
   "method" : {
@@ -47,7 +45,7 @@ var schemify = function(data, level) {
     })
     if(typeof uniq[0] == "object") {
       var result = {}
-      uniq.forEach(function(item){ deepExtend(result, item) })
+      uniq.forEach(function(item){ _.merge(result, item) })
       return [result]
     } else
       return uniq
@@ -72,17 +70,17 @@ var schemifyAndUpdate = function(sample, samples) {
     } else
       return typeof r.res.body == typeof sample.res.body && !Array.isArray(r.res.body)
   })
-  
+
   if(!found)
     return samples.push(sample)
-  
+
   if(found.req.url != sample.req.url)
     found.req.url = aggregateReqPath(found.req.url, sample.req.url)
   found.req.method = sample.req.method
-  deepExtend(found.req.headers, sample.req.headers)
-  deepExtend(found.req.body, sample.req.body)
-  deepExtend(found.res.headers, sample.res.headers)
-  deepExtend(found.res.body, sample.res.body)
+  _.merge(found.req.headers, sample.req.headers)
+  _.merge(found.req.body, sample.req.body)
+  _.merge(found.res.headers, sample.res.headers)
+  _.merge(found.res.body, sample.res.body)
 }
 
 var remember = function(req, res, res_body) {

--- a/lib/render-docs-metadata/index.js
+++ b/lib/render-docs-metadata/index.js
@@ -1,5 +1,4 @@
 var fs = require("fs")
-var _ = require("underscore")
 
 var dumpSuccessfulRequests = function(action){
   var result = ""

--- a/package.json
+++ b/package.json
@@ -16,18 +16,15 @@
     "organic-plasma": "0.0.6"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "clone": "~0.1.17",
-    "deep-extend": "^0.3.2",
+    "async": "^1.5.0",
     "ejs": "^2.0.8",
-    "esprima": "~1.2.2",
+    "esprima": "^2.7.1",
     "express-buffer-response": "^1.0.3",
-    "glob-stream": "^4.0.0",
+    "glob-stream": "^5.3.1",
+    "lodash": "^3.10.1",
     "markedejs": "~0.1.0",
     "methods": "^1.1.1",
-    "on-finished": "^2.2.0",
-    "organic-nucleus": "0.0.1",
-    "underscore": "~1.6.0"
+    "organic-nucleus": "0.0.1"
   },
   "repository": {
     "type": "git",

--- a/template/index.html
+++ b/template/index.html
@@ -13,7 +13,7 @@
   <% include ./header.html %>
 
   <% for (var i = 0; i < doc.apis.length; i++) { %>
-    <section class="markdown-body" data-sticky_parent> 
+    <section class="markdown-body" data-sticky_parent>
       <div class="mini-toc" data-sticky_column>
         <div>
           <a name="<%= doc.apis[i].baseUrl %>"></a>
@@ -63,7 +63,7 @@
       <div class="clear"></div>
     </section>
   <% } %>
-        
+
   <a id="topBtn" href="#">TOP</a>
 
 </body>

--- a/template/styles.html
+++ b/template/styles.html
@@ -44,7 +44,7 @@
     border-radius: 5px;
   }
   .action {
-    
+
   }
   .action .method {
     font-size: 2em;
@@ -52,7 +52,7 @@
   .action .url {
     font-size: 1.5em;
   }
-  
+
   #topBtn {
     position: fixed;
     right: 150px;
@@ -64,7 +64,7 @@
   .is_stuck_above_all {
     z-index: 1000;
   }
-  
+
   .metadata {
     max-width: 960px;
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,7 +39,7 @@ describe("index", function(){
       expect(c.data.docs).to.exist
       expect(c.data.docs.length).to.be.equal(1)
       expect(c.data.docs[0].name).to.be.equal("organic-express-api-doc")
-      expect(c.data.docs[0].version).to.be.equal("0.2.2")
+      expect(c.data.docs[0].version).to.exist
       expect(c.data.docs[0].apis).to.exist
       expect(c.data.docs[0].apis.length).to.be.equal(1)
       expect(c.data.html).to.exist


### PR DESCRIPTION
Updated to work with node v4 code or 0.12.x harmony code. Main point is the upgrade of `esprima` to 2.x which supports ES6.

Additionally:
- Replaced `underscore`, `deep-extend` and `clone` with `lodash`
- Added `HISTORY.md`
- Fixed broken test
- Minor whitespace fixes
